### PR TITLE
Fix importo calculation for unmatched movements

### DIFF
--- a/prestazioni.html
+++ b/prestazioni.html
@@ -730,8 +730,8 @@
                 
                 notMatched.forEach(item => {
                     const controparte = findColumnValue(item.movimento, ['CONTROPARTE', 'Controparte', 'BENEFICIARIO', 'Beneficiario']) || 'N/D';
-                    const importoNetto = getImportoFromMovimento(item.movimento) * 0.8;
-                    const importoLordo = getImportoFromMovimento(item.movimento);
+                    const importoLordo = getImportoSingoloMovimento(item.movimento);
+                    const importoNetto = importoLordo * 0.8;
                     
                     html += `
                         <tr>


### PR DESCRIPTION
## Summary
- use `getImportoSingoloMovimento` to retrieve unmatched movement amounts
- derive net amounts from the gross value to mirror existing logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbe1875fd88324b08c90a05f954e7a